### PR TITLE
Add GitHub login, rework data flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12416,6 +12416,11 @@
         "harmony-reflect": "^1.4.6"
       }
     },
+    "idx": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/idx/-/idx-2.5.6.tgz",
+      "integrity": "sha512-WFXLF7JgPytbMgelpRY46nHz5tyDcedJ76pLV+RJWdb8h33bxFq4bdZau38DhNSzk5eVniBf1K3jwfK+Lb5nYA=="
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -17213,6 +17218,15 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ="
+    },
+    "onegraph-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onegraph-auth/-/onegraph-auth-2.0.1.tgz",
+      "integrity": "sha512-ynW6wOB0fGgTc4VWq9Ke/GgfD+3Dlq7itfWh8UMP3amv3mULoYJ3398HXsX8oJbWZQVXy2cuzIqmVQBeucVTzQ==",
+      "requires": {
+        "idx": "^2.2.0",
+        "regenerator-runtime": "^0.11.1"
+      }
     },
     "onetime": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "immutable": "3.8.2",
     "lodash": "^4.17.13",
     "netlify-styleguide": "^0.1.7",
+    "onegraph-auth": "^2.0.1",
     "prettier": "1.18.2",
     "promisingagent": "5.3.2",
     "react": "16.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // replace with hooks and new React path
 import React, {Component} from "react";
 import NewRepo from "./containers/NewRepo";
@@ -7,56 +6,23 @@ import Footer from "./components/Footer";
 import Header from "./components/Header";
 import {BrowserRouter as Router, Route} from "react-router-dom";
 import auth from "./hoc/AuthHOC";
-import {loginUser, logoutUser} from "./lib/identityActions";
-import {graphql} from "react-apollo";
-import {viewerQuery} from "./queries";
-import cookie from "react-cookies";
 
 export class App extends Component {
-  state = {user: null};
-
-  componentDidMount() {
-    const user = localStorage.getItem("currentOpenSaucedUser");
-
-    if (user) {
-      this.setState({user: user});
-    } else {
-      loginUser();
-    }
-
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const user = localStorage.getItem("currentOpenSaucedUser");
-    const {viewer} = nextProps.data;
-
-    if (user && nextProps.data.loading !== this.props.data.loading) {
-      if (viewer) {
-        this.saveViewerId(viewer.id);
-      }
-    }
-  }
-
-  saveViewerId = id => {
-    cookie.save("openSaucedViewerId", id);
-  };
-
-  logOutViewer = () => {
-    cookie.remove("openSaucedViewerId");
-    logoutUser();
-  };
-
   render() {
-    const {user} = this.state;
+    const {handleLogIn, handleLogOut, user} = this.props;
+    const guard = component => {
+      return auth(component, user, handleLogIn);
+    };
+
     return (
       <Router>
         <div>
-          {user && <Header user={user} />}
+          {user && <Header user={user} handleLogOut={handleLogOut} />}
           <section>
-            <Route exact path="/" component={auth(Repositories)} />
-            <Route path="/repos" component={auth(Repositories)} />
-            <Route path="/callback" component={auth(Repositories)} />
-            <Route path="/new" component={auth(NewRepo)} />
+            <Route exact path="/" component={guard(Repositories)} />
+            <Route path="/repos" component={guard(Repositories)} />
+            <Route path="/callback" component={guard(Repositories)} />
+            <Route path="/new" component={guard(NewRepo)} />
           </section>
           <Footer />
         </div>
@@ -65,15 +31,4 @@ export class App extends Component {
   }
 }
 
-const currentUser = localStorage.getItem("currentOpenSaucedUser");
-const queryOptions = {
-  options: {
-    variables: {
-      id: currentUser ? currentUser : "",
-    },
-  },
-};
-
-const AppWithUserData = graphql(viewerQuery, queryOptions)(App);
-
-export default AppWithUserData;
+export default App;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,14 +4,8 @@ import {home, github, plus, logout, issue} from "../icons";
 import {Link} from "react-router-dom";
 import {FloatLeft} from "../styles/Grid";
 
-const handleLogIn = () => {
-};
-
-const handleLogOut = () => {
-};
-
-const Header = ({user}) => {
-  return user ? (
+const Header = ({user, handleLogOut}) => {
+  return (
     <header>
       <FloatLeft>
         <Link to="/" className="home" alt="home">
@@ -40,13 +34,9 @@ const Header = ({user}) => {
           <img src={github} />
         </span>
       </a>
-    </header>
-  ) : (
-    <header>
-      <a onClick={handleLogIn}>Welcome to Open Sauced</a>
-      <a className="nav-link" target="_blank" href="https://github.com/bdougie/open-sauced/issues/new">
+      <a className="nav-link" href="https://github.com/bdougie/open-sauced">
         <span>
-          <img src={issue} />
+            Hi, {user.email}!
         </span>
       </a>
     </header>

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,34 +1,20 @@
 import React, {Component} from "react";
-import {loginUser} from "../lib/identityActions";
 import {createViewer} from "../queries";
 import {graphql} from "react-apollo";
-import GitHubLogin from "react-github-login";
 import logo from "./logo8.svg";
 import {FlexCenter} from "../styles/Grid";
 
 const spacingStyle = {margin: "auto", padding: 100, textAlign: "center"};
-const onSuccess = response => {
-  loginUser(response);
-};
-
-const onFailure = response => console.error(response);
 
 export class Login extends Component {
-  // handleLogin = () => {}//netlifyIdentity.open();
-
   render() {
+    const {handleLogIn} = this.props;
     return (
       <FlexCenter>
         <div style={spacingStyle}>
-          {/* <Button onClick={this.handleLogin}>Login to get saucin</Button> */}
           <img src={logo} alt="logo" />
           <p style={{marginTop: 16}}>The path towards open-source contributions. Login to get Saucin'</p>
-          <GitHubLogin
-            clientId="add06b2f1ac97fd583a6"
-            redirectUri="http://localhost:3000/callback"
-            onSuccess={onSuccess}
-            onFailure={onFailure}
-          />
+          <button onClick={handleLogIn}>Sign in with GitHub</button>
         </div>
       </FlexCenter>
     );

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+import OneGraphAuth from "onegraph-auth";
+
+const APP_ID = "e2ce0bcc-b5b6-42b7-a28e-3a6579d69ecd";
+
+const auth = new OneGraphAuth({
+  appId: APP_ID
+});
+
+export default {auth: auth, appId: APP_ID};

--- a/src/hoc/AuthHOC.js
+++ b/src/hoc/AuthHOC.js
@@ -1,11 +1,10 @@
 import React from "react";
 import Login from "../components/Login";
 
-export default function requireAuthentication(Component) {
-  class AuthHOC extends Component {
+export default function requireAuthentication(Component, user, handleLogIn) {
+  class AuthHOC extends React.Component {
     render() {
-      const user = localStorage.getItem("currentOpenSaucedUser");
-      return user ? <Component {...this.props} /> : <Login />;
+      return user ? <Component {...this.props} /> : <Login handleLogIn={handleLogIn} />;
     }
   }
   return AuthHOC;

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,83 @@
+/* eslint-disable */
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
-import {ApolloProvider, ApolloClient, createNetworkInterface} from "react-apollo";
+import {
+  ApolloProvider,
+  ApolloClient,
+  createNetworkInterface
+} from "react-apollo";
+import Config from "./config";
+import {getUserFromJwt} from "./lib/identityActions";
 import "./index.css";
 import registerServiceWorker from "./registerServiceWorker";
 
 const client = new ApolloClient({
-  networkInterface: createNetworkInterface({uri: `${process.env.graphcoolEndpoint}`}),
-  dataIdFromObject: o => o.id,
+  networkInterface: createNetworkInterface({
+    uri: `${process.env.graphcoolEndpoint}`
+  }),
+  dataIdFromObject: o => o.id
 });
 
-ReactDOM.render(
-  <ApolloProvider client={client}>
-    <App />
-  </ApolloProvider>,
-  document.getElementById("root"),
-);
+class Index extends React.Component {
+  state = {user: null};
+
+  componentDidMount() {
+    const auth = Config.auth;
+    auth.isLoggedIn("github").then(isLoggedIn => {
+      if (isLoggedIn) {
+        const user = getUserFromJwt(auth);
+        this.setState({user: user})
+      } else {
+        console.warn("User is not logged into GitHub");
+      }
+    });
+  }
+
+  _handleLogIn() {
+    const auth = Config.auth;
+    auth
+      .login("github")
+      .then(() => {
+        auth.isLoggedIn("github").then(isLoggedIn => {
+          if (isLoggedIn) {
+            // Pull the user-data we care about from the JWT and
+            // store it in component local state for the rest of the
+            // app
+            const user = getUserFromJwt(auth);
+            this.setState({user: user});
+          } else {
+            console.warn("User did not grant auth for GitHub");
+          }
+        });
+      })
+      .catch(e => console.error("Problem logging in", e));
+  }
+
+  _handleLogOut() {
+    const auth = Config.auth;
+    auth.logout("github").then(() => {
+      // Remove the local onegraph-auth storage
+      localStorage.removeItem("oneGraph:" + Config.appId);
+      this.setState({user: null})
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <ApolloProvider client={client}>
+          <App user={this.state.user}
+            userId={this.state.user && this.state.user.id}
+            handleLogIn={() => this._handleLogIn()}
+            handleLogOut={() => this._handleLogOut()}
+          />
+        </ApolloProvider>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<Index />, document.getElementById("root"));
 
 registerServiceWorker();

--- a/src/lib/identityActions.js
+++ b/src/lib/identityActions.js
@@ -1,7 +1,7 @@
-export function loginUser(response) {
-  response && localStorage.setItem("currentOpenSaucedUser", response.code);
-}
+export function getUserFromJwt(auth) {
+  const rawJwt = auth.accessToken() || {};
+  const jwtPayload = (rawJwt.accessToken || "").split(".")[1];
+  const decodedString = atob(jwtPayload || "") || "{}";
 
-export function logoutUser() {
-  localStorage.removeItem("currentOpenSaucedUser");
+  return JSON.parse(decodedString).user;
 }

--- a/src/lib/identityActions.test.js
+++ b/src/lib/identityActions.test.js
@@ -1,22 +1,21 @@
-import {loginUser, logoutUser} from "./identityActions";
-const VALUE = "abc123";
-const KEY = "currentOpenSaucedUser";
+/* eslint-disable */
+import { getUserFromJwt } from "./identityActions";
+
+const mockedOneGraphAuth = {
+  accessToken: () => {
+    const mockedPayload = btoa(
+      JSON.stringify({ user: { email: "test@test.com", id: 123 } })
+    );
+    // Mocked JWT
+    const accessToken = "header." + mockedPayload + ".signature";
+    return { accessToken };
+  }
+};
 
 describe("loginUser", () => {
-  const response = {code: VALUE};
-
-  it("should initialize app withou a user set", () => {
-    expect(localStorage.getItem(KEY)).toBeNull();
-  });
-
-  it("should set user when logging in", () => {
-    loginUser(response);
-    expect(localStorage.setItem).toHaveBeenLastCalledWith(KEY, VALUE);
-  });
-
-  it("should remove user when logging out", () => {
-    loginUser(response);
-    logoutUser();
-    expect(localStorage.getItem(KEY)).toBeNull();
+  it("should decode a user from a JWT via onegraph-auth", () => {
+    const user = getUserFromJwt(mockedOneGraphAuth);
+    expect(user.email).toBe("test@test.com");
+    expect(user.id).toBe(123);
   });
 });

--- a/src/tests/Header.test.js
+++ b/src/tests/Header.test.js
@@ -3,8 +3,9 @@ import {shallow} from "enzyme";
 import Header from "../components/Header";
 
 describe("<Header />", () => {
-  it("should render without throwing an error", () => {
-    const component = shallow(<Header />);
+  it("should render without throwing an error when a user is provided", () => {
+    const user = {email: "test@test.com", id: 123};
+    const component = shallow(<Header user={user} />);
     expect(component).toBeDefined();
     expect(component.exists()).toBe(true);
   });


### PR DESCRIPTION
I tried to make this minimally invasive, but it's a bigger change than I was hoping. The good news is, it's mostly deletions!

I moved the logic for knowing if a user is logged in or not to the top of the app, so `App` no longer needs to be wrapped in a `graphql` component. I also removed the use of local storage (other than the onegraph-auth token). On first starting, the app will make a call to GitHub to see if the user is logged in - if so, it uses the email/id pairing from the JWT and renders the inner app. If not, it displays the `Login` component.

I also updated the tests to pass with the new changes, but I did struggle with the eslint rules though, especially for the class constructs.

Happy to work on this some more if it looks like a direction you'd like to take it in! If so, I'd recommend just using the OneGraph code exporter to be able to copy/paste the relevant github queries in `apiGraphQL.js`. That way you can use the onegraph-auth token to hit GitHub's API on *their* behalf, and you won't have to expose your personal token. I can take a stab at this and record a quick video of it in the process, should take ~10 min or so.