### PR TITLE
Release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-sauced",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
This release includes various dependency updates

* Bump enzyme-adapter-react-16 from 1.14.0 to 1.15.1 (#299) @dependabot-preview
* Bump @storybook/addon-actions from 5.2.1 to 5.2.3 (#292) @dependabot-preview
* Bump @storybook/addons from 5.2.1 to 5.2.3 (#290) @dependabot-preview
* Bump @babel/preset-env from 7.6.2 to 7.6.3 (#298) @dependabot-preview
* Bump @babel/preset-react from 7.0.0 to 7.6.3 (#301) @dependabot-preview
* Bump @storybook/addon-links from 5.2.3 to 5.2.4 (#300) @dependabot-preview
* Bump @storybook/react from 5.2.3 to 5.2.4 (#302) @dependabot-preview
* Bump filesize from 5.0.1 to 5.0.2 (#291) @dependabot-preview
* Bump cross-spawn from 7.0.0 to 7.0.1 (#293) @dependabot-preview
* Bump yarn from 1.19.0 to 1.19.1 (#294) @dependabot-preview
* Bump @storybook/react from 5.2.1 to 5.2.3 (#288) @dependabot-preview
* Bump @storybook/addon-links from 5.2.1 to 5.2.3 (#287) @dependabot-preview