### PR TITLE
bump version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.12]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.12]
 
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-sauced",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
## What’s Changed

* Bump @primer/components from 14.3.1 to 15.0.1 (#318) @dependabot-preview
* Bump filesize from 5.0.2 to 5.0.3 (#313) @dependabot-preview
* Bump dotenv from 8.1.0 to 8.2.0 (#317) @dependabot-preview
* Bump @storybook/addon-actions from 5.2.3 to 5.2.4 (#311) @dependabot-preview
* Bump stylelint from 11.0.0 to 11.1.1 (#314) @dependabot-preview
* Bump @babel/core from 7.6.2 to 7.6.4 (#310) @dependabot-preview
* Bump @primer/octicons-react from 9.1.1 to 9.2.0 (#312) @dependabot-preview
* Bump react-apollo from 3.1.2 to 3.1.3 (#315) @dependabot-preview
* Leveraging more react hooks (#286) @bdougie