### PR TITLE
open-sauced-goals repo gets created with visibility as private by default

### DIFF
--- a/src/lib/apiGraphQL.js
+++ b/src/lib/apiGraphQL.js
@@ -195,7 +195,7 @@ const operationsDoc = `
     gitHub {
       createRepository(
         input: {
-          visibility: PUBLIC
+          visibility: PRIVATE
           name: "open-sauced-goals"
           description: "A list of contributions I might like to make some day!"
         }


### PR DESCRIPTION
1. manually tested, repo gets created as private.
2. ```npm test``` passes all test suites