### PR TITLE
Fix all broken widths

### DIFF
--- a/src/components/RepositoryGoals.js
+++ b/src/components/RepositoryGoals.js
@@ -17,9 +17,7 @@ function RepositoryGoals() {
   const {repository} = goalsReducer(state, {type: "GET"});
 
   useEffect(() => {
-    if (repository !== undefined) {
-      setGoalsId(repository.id);
-    }
+    repository && setGoalsId(repository.id);
   }, [goalsId]);
 
   const onRepoCreation = repo => {

--- a/src/components/RepositoryGoals.js
+++ b/src/components/RepositoryGoals.js
@@ -48,10 +48,10 @@ function RepositoryGoals() {
 
   return repository && repository.issues ? (
     <React.Fragment>
-      {/* remove maxMidth when more cards are added*/}
-      <ContextStyle style={{maxWidth: 880}}>
+      <ContextStyle>
         <SpaceBetween>
-          <React.Fragment>
+          <div className="context-div">
+            {" "}
             <h1>Dashboard</h1>
             <p>
               Open Sauced is a project to track the contributions you would like to work on. Add a repository you are
@@ -65,7 +65,7 @@ function RepositoryGoals() {
                 </a>
               </em>
             </small>
-          </React.Fragment>
+          </div>
           <Illustration alt="done checking image" src={doneChecking} />
         </SpaceBetween>
       </ContextStyle>


### PR DESCRIPTION
# What is this?

This fixes a few problems.

1. Widths were all broken due to React.Fragment does not respect the same qualities as a div. 
2. The more verbose check for repository does not account for null and was failing for any login that had not created a repository. I had to go back to the && check