### PR TITLE
improve reducer error tests

### DIFF
--- a/src/lib/reducers.test.js
+++ b/src/lib/reducers.test.js
@@ -17,10 +17,6 @@ describe("goalsReducer", () => {
   });
 
   it("should error on no action type", () => {
-    try {
-      goalsReducer(state, {});
-    } catch (e) {
-      expect(e).toEqual(new Error("No Action was provided."));
-    }
+    expect(goalsReducer.bind(null, state, {})).toThrow(new Error("No Action was provided."));
   });
 });


### PR DESCRIPTION
As soon as I posted my experience on Twitter, I received [some feedback]([https://twitter.com/hugo__df/status/1215768310131908610](https://twitter.com/hugo__df/status/1215768310131908610)) that my test would still pass if the function stopper throwing the error. Instead I was recommended to [fail fast with Jest](https://codewithhugo.com/jest-force-explicitly-fail-test/). Failing fast is using [toThrow()](https://jestjs.io/docs/en/expect#tothrowerror), which I originally attempted. My mistake when trying out this expectation was not [binding the function](https://www.geeksforgeeks.org/javascript-function-binding/) to provide the error. 
