### PR TITLE
removes box-css

### DIFF
--- a/src/styles/Grid/Flex.js
+++ b/src/styles/Grid/Flex.js
@@ -46,8 +46,6 @@ const SpaceAround = styled.div`
 const SpaceBetween = styled.div`
   display: flex;
   display: -webkit-flex;
-  display: -webkit-box;
-  display: -moz-box;
   display: -ms-flexbox;
   justify-content: space-between;
 


### PR DESCRIPTION
I discovered that the following was overriding the flexbox.

```
  display: -webkit-box;	
  display: -moz-box;
```

closes #455 