### PR TITLE
bug fix(#524) Failure when adding repos after the initial goals repo creation.

### DIFF
--- a/src/components/CreateGoals.js
+++ b/src/components/CreateGoals.js
@@ -10,7 +10,18 @@ import {devProductive} from "../illustrations";
 function CreateGoals({onRepoCreation}) {
   const _handleRepoCreation = () => {
     api.createOpenSaucedGoalsRepo().then(res => {
-      onRepoCreation(goalsReducer(res, {type: "CREATE"}));
+      console.log(res);
+      const {
+        data: {
+          gitHub: {
+            createRepository: {
+              repository: {id},
+            },
+          },
+        },
+      } = res;
+
+      onRepoCreation(id, goalsReducer(res, {type: "CREATE"}));
     });
   };
 

--- a/src/components/CreateGoals.js
+++ b/src/components/CreateGoals.js
@@ -10,7 +10,6 @@ import {devProductive} from "../illustrations";
 function CreateGoals({onRepoCreation}) {
   const _handleRepoCreation = () => {
     api.createOpenSaucedGoalsRepo().then(res => {
-      console.log(res);
       const {
         data: {
           gitHub: {

--- a/src/components/NoteForm.js
+++ b/src/components/NoteForm.js
@@ -39,7 +39,6 @@ function NoteForm({goalId, repoName, note}) {
   };
 
   const noteContent = input !== "" ? input : note;
-  console.log(deleted);
 
   return !deleted ? (
     <Card>

--- a/src/components/NoteForm.js
+++ b/src/components/NoteForm.js
@@ -24,7 +24,6 @@ function NoteForm({goalId, repoName, note}) {
     api
       .updateGoal(goalId, repoName, "CLOSED", input)
       .then(res => {
-        console.log(res);
         setEditing(false);
         setDeleted(true);
       })
@@ -40,12 +39,9 @@ function NoteForm({goalId, repoName, note}) {
   };
 
   const noteContent = input !== "" ? input : note;
+  console.log(deleted);
 
-  if (deleted) {
-    <Redirect to="/" />;
-  }
-
-  return (
+  return !deleted ? (
     <Card>
       <TextArea
         style={{minHeight: 170}}
@@ -75,6 +71,8 @@ function NoteForm({goalId, repoName, note}) {
         </Button>
       </FlexCenter>
     </Card>
+  ) : (
+    <Redirect to="/" />
   );
 }
 

--- a/src/components/RepositoryGoals.js
+++ b/src/components/RepositoryGoals.js
@@ -20,8 +20,9 @@ function RepositoryGoals() {
     repository && setGoalsId(repository.id);
   }, [goalsId]);
 
-  const onRepoCreation = repo => {
+  const onRepoCreation = (id, repo) => {
     dispatch({type: "CREATE", payload: repo});
+    setGoalsId(id)
   };
 
   const onGoalAdded = goal => {


### PR DESCRIPTION
fixes #524 

# What happened?
The migration from lifecycle methods to hooks introduced a number of bugs. In this case, the id of the created "open-sauced-goals" repo was not being stored in globalState (context) of the App. This id is needed to do anything because the repo is the backbone (of the database for this project). 

# The Fix

I am passing the id directly to the `onRepoCreatio` callback. I am not relying on the `goalsReducer` to do this because I want this update to happen immediately. 

## fixed another bug

While testing another page to see how the back updates to components worked, I found that the **NoteForm.js** deletion handler was not updating. Also due to a switch to using hooks. I move the `Redirect` into the main render to fix it. 