### PR TITLE
Make open-sauced-goals public by default

### DIFF
--- a/src/components/CreateGoals.js
+++ b/src/components/CreateGoals.js
@@ -25,7 +25,7 @@ function CreateGoals({onRepoCreation}) {
                 Open Sauced is a tool to help track your next open source contributions. You can get started by creating
                 a goal workspace below.
               </p>
-              <p>A private repository name "open-sauced-goals" will be created on your GitHub account to store.</p>
+              <p>A public repository name "open-sauced-goals" will be created on your GitHub account to store.</p>
               <small>
                 <em>You own all your data saved while saucin.</em>
               </small>

--- a/src/lib/apiGraphQL.js
+++ b/src/lib/apiGraphQL.js
@@ -232,7 +232,7 @@ const operationsDoc = `
     gitHub {
       createRepository(
         input: {
-          visibility: PRIVATE
+          visibility: PUBLIC
           name: "open-sauced-goals"
           description: "A list of contributions I might like to make some day!"
         }


### PR DESCRIPTION
# Why?
I originally planned to have this project make private repos on behalf of the user. IMO open source contributions are easier when you explicitly state you are looking to help, which is why I am switching this flag to be open by default. 