### PR TITLE
Add loading until repo name loads

### DIFF
--- a/src/components/Repository.js
+++ b/src/components/Repository.js
@@ -65,7 +65,11 @@ function Repository({match}) {
         <SpaceBetween>
           <div className="context-div">
             <a style={{textDecoration: "none"}} href={url} target="_blank">
-              <h1>{nameWithOwner}</h1>
+              {nameWithOwner ? (
+                <h1>{nameWithOwner}</h1>
+              ) : (
+                <h1>Loading...</h1>
+              )}
             </a>
             <p>
               Use the issue list to find things to work on. The notes form is here to also assist with the tracking


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add loading until repo name loads, I think spinner is not suitable here!

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

![Screenshot](https://user-images.githubusercontent.com/61746440/82747561-cfda7d00-9db7-11ea-8d7a-903353adc587.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] readme
- [x] no documentation needed