### PR TITLE
Allow return key to add repositories

### DIFF
--- a/src/components/AddRepoForm.js
+++ b/src/components/AddRepoForm.js
@@ -9,7 +9,8 @@ import {isValidRepoUrl} from "../lib/util";
 function AddRepoForm({goalsId, onGoalAdded}) {
   const urlRef = useRef(null);
 
-  const _handleGoalCreation = () => {
+  const _handleGoalCreation = (event) => {
+    event.preventDefault();
     if (!urlRef.current.value) {
       urlRef.current.focus();
       console.warn("required");
@@ -33,14 +34,16 @@ function AddRepoForm({goalsId, onGoalAdded}) {
   };
 
   return (
-    <CardPadding>
-      <Flex>
-        <Input aria-label="repo name with owner" type="text" ref={urlRef} placeholder="owner/repo" />
-        <InputButton primary onClick={_handleGoalCreation}>
-          Add
-        </InputButton>
-      </Flex>
-    </CardPadding>
+    <form onSubmit={_handleGoalCreation}>
+      <CardPadding>
+        <Flex>
+          <Input aria-label="repo name with owner" type="text" ref={urlRef} placeholder="owner/repo" />
+          <InputButton type="submit" primary onClick={_handleGoalCreation}>
+            Add
+          </InputButton>
+        </Flex>
+      </CardPadding>
+    </form>
   );
 }
 

--- a/src/components/AddRepoForm.js
+++ b/src/components/AddRepoForm.js
@@ -38,7 +38,7 @@ function AddRepoForm({goalsId, onGoalAdded}) {
       <CardPadding>
         <Flex>
           <Input aria-label="repo name with owner" type="text" ref={urlRef} placeholder="owner/repo" />
-          <InputButton type="submit" primary onClick={_handleGoalCreation}>
+          <InputButton type="submit" primary>
             Add
           </InputButton>
         </Flex>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Release

## Description
This turns the add repo input into a form element. This way the `_handleGoalCreation` function runs when the form is sumbitted, which can be done by pressing either the sumbit button or return key.

## Related Tickets & Documents
#554 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Happy Pikachu](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)
